### PR TITLE
refactor: simplify copy, move verification, move helper function to separate files

### DIFF
--- a/JavaStorageCleaner/src/main/java/JavaStorageCleaner.java
+++ b/JavaStorageCleaner/src/main/java/JavaStorageCleaner.java
@@ -27,19 +27,19 @@ public class JavaStorageCleaner {
 
         Files.walk(Paths.get(sourceDir))
                 .forEach(source -> {
-                    BasicFileAttributeView basicView = Files.getFileAttributeView(source, BasicFileAttributeView.class);
-                    BasicFileAttributes basicAttribs = null;
                     try {
-                        basicAttribs = basicView.readAttributes();
+                        if (!Files.isDirectory(source)) { // ignore directories
+                            FileTime sourceModifiedTime = Files.getLastModifiedTime(source);
+                            if (sourceModifiedTime.compareTo(fromFileTime) >= 0
+                                    && sourceModifiedTime.compareTo(toFileTime) <= 0) {
+                                filterResults.add(source);
+                            }
+                        }
                     } catch (IOException e) {
-                        System.err.println("Error in read attributes");
-                        e.printStackTrace();
-                    }
-                    if (basicAttribs.lastModifiedTime().compareTo(fromFileTime) >= 0
-                            && basicAttribs.lastModifiedTime().compareTo(toFileTime) <= 0) {
-                        filterResults.add(source);
+                        System.err.println("Error in getting modified time: " + source);
                     }
                 });
+
         return filterResults;
     }
 
@@ -72,12 +72,10 @@ public class JavaStorageCleaner {
         Files.walk(Paths.get(sourceDirectory))
                 .forEach(source -> {
                     // destination = destinationDirectoryLocation + File(Directory)
-                    // source.toString() ~ length(): get file name
                     Path destination = Paths.get(destinationDirectory, source.toString()
                             .substring(sourceDirectory.length()));
                     try {
                         // copy
-                        // REPLACE_EXISTING: replace original file when copies
                         Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
                     } catch (IOException e) {
                         System.err.println("Error in copying inside copyDirectory()");

--- a/JavaStorageCleaner/src/test/java/JavaStorageCleanerTest.java
+++ b/JavaStorageCleaner/src/test/java/JavaStorageCleanerTest.java
@@ -8,9 +8,11 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import static helper.JavaStorageCleanerTestHelper.deleteRecursively;
+import static helper.JavaStorageCleanerTestHelper.fileSizeEquals;
+import static helper.JavaStorageCleanerTestHelper.verifyCopy;
+import static helper.JavaStorageCleanerTestHelper.verifyMove;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JavaStorageCleanerTest {
@@ -37,7 +39,7 @@ class JavaStorageCleanerTest {
     @Test
     void fastCopyTest() {
         String sourceDir = commonPath + "/filterTest/card2(2164).py";
-        String targetDir = commonPath +"/card2(2164).py";
+        String targetDir = commonPath + "/card2(2164).py";
         Path sourcePath = Paths.get(sourceDir);
         Path targetPath = Paths.get(targetDir);
         JavaStorageCleaner.fastCopy(sourcePath, targetPath);
@@ -126,6 +128,7 @@ class JavaStorageCleanerTest {
         } catch (IOException e2) {
             e2.printStackTrace();
         }
+
         // rollback
         try {
             JavaStorageCleaner.moveDirectory(cloudDir, sourceDir);
@@ -158,9 +161,13 @@ class JavaStorageCleanerTest {
         String sourceDir = commonPath + "/filterTest";
         List<Path> fileList = new ArrayList<Path>();
         LocalDate fromDate = LocalDate.of(2024, 4, 1);
-        LocalDate toDate = LocalDate.of(2024, 5, 10);
+        LocalDate toDate = LocalDate.of(2024, 6, 4);
         List<Path> filterList = new ArrayList<>();
         // sample data to test
+        fileList.add(Paths.get(sourceDir + "/parent_of_tree(11725).py"));
+        fileList.add(Paths.get(sourceDir + "/ordinary_bag(12865).py"));
+        fileList.add(Paths.get(sourceDir + "/parent_of_tree(11725).py"));
+        fileList.add(Paths.get(sourceDir + "/ordinary_bag(12865).py"));
         fileList.add(Paths.get(sourceDir + "/parent_of_tree(11725).py"));
         fileList.add(Paths.get(sourceDir + "/ordinary_bag(12865).py"));
 
@@ -170,14 +177,15 @@ class JavaStorageCleanerTest {
             e1.printStackTrace();
         }
 
-        try {
-            for (Path fp : filterList) {
-                System.out.println("filterList: " + fp);
-            }
 
-            for (Path flp : fileList) {
-                System.out.println("fileList: " + flp);
-            }
+        try { // for debugging
+//            for (Path fp : filterList) {
+//                System.out.println("filterList: " + fp);
+//            }
+//
+//            for (Path flp : fileList) {
+//                System.out.println("fileList: " + flp);
+//            }
 
             assertTrue(verifyFileFilter(filterList, fileList));
         } catch (IOException e2) {
@@ -185,23 +193,24 @@ class JavaStorageCleanerTest {
         }
     }
 
-    private static boolean verifyFileFilter(List<Path> filterResult, List<Path> fileList) throws IOException {
-        // handle null cases
+    private static boolean verifyFileFilter(List<Path> filterResult, List<Path> fileList) throws IOException { // handle null cases
         if (filterResult == null || fileList == null) {
             System.out.println("null error -> false");
             return false;
         }
 
         if (filterResult.size() != fileList.size()) {
+            System.out.println("fileList size: " + fileList.size());
+            System.out.println("filterResult size: " + filterResult.size());
             System.out.println("list size different -> false");
             return false;
         }
 
         for (int i = 0; i < filterResult.size(); i++) {
             // for debugging
-//             System.out.println("filterResult: " + filterResult.get(i) + "\nfileList: " + fileList.get(i));
-            if (!fileContentEquals(filterResult.get(i), fileList.get(i))) {
-                System.out.println("file content not same -> false");
+             System.out.println("filterResult: " + filterResult.get(i) + "\nfileList: " + fileList.get(i));
+            if (!fileSizeEquals(filterResult.get(i), fileList.get(i))) {
+                System.out.println("file size not same -> false");
                 return false;
             }
         }
@@ -209,130 +218,5 @@ class JavaStorageCleanerTest {
         return true;
     }
 
-    // method to delete a file or directory recursively
-    private static void deleteRecursively(String pathStr) throws IOException {
-        Path path = Paths.get(pathStr);
-        if (Files.isDirectory(path)) {
-            // walk through the directory and delete all files and subdirectories
-            try (Stream<Path> stream = Files.walk(path)) {
-                stream.sorted((a, b) -> b.compareTo(a))  // Reverse order to delete children first
-                        .forEach(p -> {
-                            try {
-                                Files.delete(p);
-                                System.out.println("Deleted: " + p);
-                            } catch (IOException e) {
-                                throw new RuntimeException("Failed to delete: " + p, e);
-                            }
-                        });
-            }
-        } else {
-            // delete a single file
-            Files.delete(path);
-            System.out.println("Deleted: " + path);
-        }
-    }
-
-    // method to verify the copied directory and files
-    private static boolean verifyCopy(String sourceDirectoryLocation, String destinationDirectoryLocation) throws IOException {
-        Path sourceDir = Paths.get(sourceDirectoryLocation);
-        Path targetDir = Paths.get(destinationDirectoryLocation);
-
-        // check if target directory exists
-        if (!Files.exists(targetDir)) {
-            System.err.println("Target directory does not exist or is not a directory.");
-            return false;
-        }
-
-        // walk source directory and compare with target directory
-        try (Stream<Path> sourceStream = Files.walk(sourceDir)) {
-            for (Path sourcePath : sourceStream.collect(Collectors.toList())) {
-                // get relative path
-                Path relativePath = sourceDir.relativize(sourcePath);
-                // extend relative path
-                Path targetPath = targetDir.resolve(relativePath);
-
-                if (Files.isDirectory(sourcePath)) {
-                    // check if directory exists in the target location
-                    if (!Files.exists(targetPath) || !Files.isDirectory(targetPath)) {
-                        System.err.println("Directory not copied: " + targetPath);
-                        return false;
-                    }
-                } else { // check if file exists and has the same content
-                    if (!Files.exists(targetPath) || !Files.isRegularFile(targetPath)) {
-                        System.err.println("File not copied or is not a regular file: " + targetPath);
-                        return false;
-                    }
-
-                    // compare file contents
-                    if (!fileContentEquals(sourcePath, targetPath)) {
-                        System.err.println("File contents differ: " + sourcePath + " and " + targetPath);
-                        return false;
-                    }
-                }
-            }
-        }
-
-        return true;
-    }
-
-    private static boolean verifyMove(String sourceDirectoryLocation, String destinationDirectoryLocation) throws IOException {
-        Path sourceDir = Paths.get(sourceDirectoryLocation);
-        Path targetDir = Paths.get(destinationDirectoryLocation);
-
-        // check if source directory exists
-        if (Files.exists(sourceDir)) {
-            System.err.println("Source directory still exists: " + sourceDir);
-            return false;
-        }
-
-        // walk source directory and compare with target directory
-        try (Stream<Path> sourceStream = Files.walk(targetDir)) {
-            for (Path targetPath : sourceStream.collect(Collectors.toList())) {
-                // get relative path
-                Path relativePath = targetDir.relativize(targetPath);
-                // extend relative path
-                Path OriginalSourcePath = sourceDir.resolve(relativePath);
-
-                if (Files.isDirectory(targetPath)) {
-                    // check if directory exists in the target location
-                    if (!Files.exists(targetPath) || !Files.isDirectory(targetPath)) {
-                        System.err.println("Directory structure mismatch or directory not found: " + targetPath);
-                        return false;
-                    }
-                } else { // check if file exists and has the same content
-                    if (!Files.exists(targetPath) || !Files.isRegularFile(targetPath)) {
-                        System.err.println("File not found or is not a regular file: " + targetPath);
-                        return false;
-                    }
-
-                    // check if we can access file contents
-                    if (!canAccessFile(targetPath)) {
-                        System.err.println("File content is not accessible: " + targetPath);
-                        return false;
-                    }
-                }
-            }
-        }
-
-        return true;
-    }
-
-    private static boolean canAccessFile(Path filePath) {
-        try {
-            Files.readAllBytes(filePath);
-            return true;
-        } catch (IOException e) {
-            System.err.println("Error reading file: " + filePath);
-            return false;
-        }
-    }
-
-    private static boolean fileContentEquals(Path path1, Path path2) throws IOException{
-        sourceBytes = Files.readAllBytes(path1);
-        targetBytes = Files.readAllBytes(path2);
-
-        if (Arrays.equals(sourceBytes, targetBytes)) return true;
-        return false;
-    }
 
 }

--- a/JavaStorageCleaner/src/test/java/helper/JavaStorageCleanerTestHelper.java
+++ b/JavaStorageCleaner/src/test/java/helper/JavaStorageCleanerTestHelper.java
@@ -1,0 +1,121 @@
+package helper;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class JavaStorageCleanerTestHelper {
+    // method to delete a file or directory recursively
+    private static ByteBuffer buffer1 = ByteBuffer.allocateDirect(1024 * 1024); // 1MB
+    private static ByteBuffer buffer2 = ByteBuffer.allocateDirect(1024 * 1024);
+
+    public static void deleteRecursively(String pathStr) throws IOException {
+        Path path = Paths.get(pathStr);
+        if (Files.isDirectory(path)) {
+            // walk through the directory and delete all files and subdirectories
+            try (Stream<Path> stream = Files.walk(path)) { // Reverse order to delete children first
+                stream.sorted(Comparator.reverseOrder()).forEach(p -> {
+                    try {
+                        Files.delete(p);
+                    } catch (IOException e) {
+                        throw new RuntimeException("Failed to delete: " + p, e);
+                    }
+                });
+            }
+        } else { // delete a single file
+            try {
+                Files.delete(path);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to delete: " + path, e);
+            }
+        }
+    }
+
+    // method to verify the copied directory and files
+    public static boolean verifyCopy(String sourceDirectoryLocation, String destinationDirectoryLocation) throws IOException {
+        Path sourceDir = Paths.get(sourceDirectoryLocation);
+        Path targetDir = Paths.get(destinationDirectoryLocation);
+
+        if (!Files.exists(targetDir)) {
+            System.err.println("Target directory does not exist or is not a directory.");
+            return false;
+        }
+
+        // walk source directory and compare with source directory
+        try (Stream<Path> sourceStream = Files.walk(sourceDir)) {
+            // get relative path from sourcePath and extend relative path to targetDir
+            for (Path sourcePath : sourceStream.collect(Collectors.toList())) {
+                // ex. sourceDir/hello.c -> relativePath: hello.c
+                //     targetDir + relativePath -> targetDir/hello.c
+                Path relativePath = sourceDir.relativize(sourcePath);
+                Path targetPath = targetDir.resolve(relativePath);
+
+                if (Files.notExists(targetPath)) {
+                    System.err.println("Target file not exists: " + targetPath);
+                    return false;
+                }
+
+                if (!(Files.isReadable(targetPath) || Files.isWritable(targetPath) || Files.isExecutable(targetPath))) {
+                    System.err.println("File content is not accessible, please check permission for the file: " + targetPath);
+                    return false;
+                }
+
+                if (!fileSizeEquals(targetPath, targetPath)) {
+                    System.err.println("File size not equals: " + targetPath + " and " + targetPath);
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public static boolean verifyMove(String sourceDirectoryLocation, String destinationDirectoryLocation) throws IOException {
+        Path sourceDir = Paths.get(sourceDirectoryLocation);
+        Path targetDir = Paths.get(destinationDirectoryLocation);
+
+        // check if source directory exists
+        if (Files.exists(sourceDir)) {
+            System.err.println("Source directory still exists: " + sourceDir);
+            return false;
+        }
+
+        // walk target directory and check
+        try (Stream<Path> targetStream = Files.walk(targetDir)) {
+            for (Path targetPath : targetStream.collect(Collectors.toList())) {
+                // throw error message when file content is not accessible by JavaCleaner
+                if (!(Files.isReadable(targetPath) || Files.isWritable(targetPath) || Files.isExecutable(targetPath))) {
+                    System.err.println("File content is not accessible, please check permission for the file: " + targetPath);
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public static boolean fileSizeEquals(Path path1, Path path2) {
+        long path1Size;
+        long path2Size;
+
+        try {
+            path1Size = Files.readAttributes(path1, "size").size();
+        } catch (IOException e) {
+            System.err.println("Cannot get file size from path1");
+            return false;
+        }
+        try {
+            path2Size = Files.readAttributes(path2, "size").size();
+        } catch (IOException e) {
+            System.err.println("Cannot get file size from path2");
+            return false;
+        }
+
+        return path1Size == path2Size;
+    }
+}


### PR DESCRIPTION
### 주요 수정 사항
**JavaStorageCleanerTest.java**
1. JavaStorageCleanerTest 테스트 코드의 helper function은 JavaStorageCleanerTestHelper 파일로 분리하였습니다.
2. Copy, Move 함수 테스트 시, 파일 전체를 읽어 확인하는 코드를 파일 크기만 확인하도록 수정했습니다.

**JavaStorageCleaner.java**
1. JavaStorageCleaner의 파일 필터 기능에서, 디렉토리는 검색되지 않도록 수정했습니다.